### PR TITLE
Update demo.html

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -9,7 +9,7 @@
 
 		<script src="http://code.jquery.com/jquery-2.0.3.min.js"></script>
 		<!--<script src="http://cytoscape.github.io/cytoscape.js/api/cytoscape.js-latest/cytoscape.js"></script>-->
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.2.11/cytoscape.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.16.1/cytoscape.js"></script>
 
 		<!-- for testing with local version of cytoscape.js -->
 		<!--<script src="../cytoscape.js/build/cytoscape.js"></script>-->


### PR DESCRIPTION
- This ensures that we know the package works & is tested with cytoscape 3.16.1 
- Not making it use cytoscape.latest as, if the package does break with future cytoscape versions, this demo file will fail.