### PR TITLE
Added support for videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ cytoscape-supportimages
 
 ## Description
 
-A plugin that enables support images on cytoscape.js -- [Demo](https://codepen.io/ninadpchaudhari/pen/rdWMJE)
+A plugin that enables support images and videos on cytoscape.js.  Supported video types are mp4, webm, and ogg. -- [Demo](https://codepen.io/ninadpchaudhari/pen/rdWMJE)
 
 Available functionalities:
  * add image

--- a/cytoscape-supportimages.js
+++ b/cytoscape-supportimages.js
@@ -607,7 +607,7 @@
             return imageCache[id].video;
         }
 
-        var video_exts = ['mp4', 'webm'];
+        var video_exts = ['mp4', 'webm', 'ogg'];
         var isVideo = video_exts.indexOf(url.slice(-3)) > -1 ? true : false;
 
         if (isVideo) {
@@ -1311,7 +1311,7 @@
                 case 'ml': cssCursor = 'w-resize'; break;
                 case 'mr': cssCursor = 'e-resize'; break;
             }
-            $('body *').css('cursor', cssCursor);
+            document.body.style.cursor = cssCursor;
         }
 
         function updateResizeControls(supportImageExt, supportImage) {

--- a/cytoscape-supportimages.js
+++ b/cytoscape-supportimages.js
@@ -725,7 +725,15 @@
               });
 
               function animateFrames(){
-                context.drawImage(img, supportImage.bounds.x, supportImage.bounds.y, supportImage.bounds.width, supportImage.bounds.height);
+                if(supportImage.selected()){
+                  context.drawImage(img, supportImage.bounds.x, supportImage.bounds.y, supportImage.bounds.width, supportImage.bounds.height);
+                  context.beginPath();
+                  context.rect(supportImage.bounds.x, supportImage.bounds.y, supportImage.bounds.width, supportImage.bounds.height);
+                  context.stroke();
+                  r.drawResizeControls(context, supportImage);
+                } else {
+                  context.drawImage(img, supportImage.bounds.x, supportImage.bounds.y, supportImage.bounds.width, supportImage.bounds.height);
+                }
                 requestAnimationFrame(animateFrames);
               }
 
@@ -735,7 +743,7 @@
             r.redraw();
         });
 
-        if (img.complete || img.readyState >= 0) {
+        if (img.complete) {
             if (!supportImage.bounds.width) {
                 supportImage.bounds.width = img.width;
             }
@@ -746,7 +754,7 @@
             var y = supportImage.bounds.y;
             var w = supportImage.bounds.width;
             var h = supportImage.bounds.height;
-            if(img.complete){ context.drawImage(img, 0, 0, img.width, img.height, x, y, w, h); }
+            context.drawImage(img, 0, 0, img.width, img.height, x, y, w, h);
 
             if (supportImage.selected()) {
                 context.beginPath();

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/cytoscape.js-supportimages.git"
+    "url": "https://github.com/harrisonmiller/cytoscape.js-supportimages.git"
   },
   "keywords": [
     "cytoscape",
@@ -16,9 +16,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/cytoscape.js-supportimages/issues"
+    "url": "https://github.com/harrisonmiller/cytoscape.js-supportimages/issues"
   },
-  "homepage": "https://github.com/cytoscape.js-supportimages",
+  "homepage": "https://github.com/harrisonmiller/cytoscape.js-supportimages",
   "devDependencies": {
     "gulp": "^3.8.10",
     "gulp-jshint": "^1.9.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/harrisonmiller/cytoscape.js-supportimages.git"
+    "url": "https://github.com/cytoscape.js-supportimages.git"
   },
   "keywords": [
     "cytoscape",
@@ -16,9 +16,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/harrisonmiller/cytoscape.js-supportimages/issues"
+    "url": "https://github.com/cytoscape.js-supportimages/issues"
   },
-  "homepage": "https://github.com/harrisonmiller/cytoscape.js-supportimages",
+  "homepage": "https://github.com/cytoscape.js-supportimages",
   "devDependencies": {
     "gulp": "^3.8.10",
     "gulp-jshint": "^1.9.2",


### PR DESCRIPTION
Hello!

I added support for videos to the extension.  Supported file types are mp4, webm, and ogg.  I create a HTML video tag using the provided url as the source and then use [requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame) to draw the video frame by frame.  The default attributes are muted, autoplay, and loop.  Let me know what you think.  I figured it might be useful to some others using the extension if it is to my team. 

You can see an example in action [here](https://knowledgeforum.org/html/demoview.html).  They are currently locked but resizing and moving them around works the same as the images when they are unlocked. 

Harrison
