### PR TITLE
Quick fix - videos not getting removed properly

### DIFF
--- a/cytoscape-supportimages.js
+++ b/cytoscape-supportimages.js
@@ -735,7 +735,7 @@
                   context.drawImage(img, supportImage.bounds.x, supportImage.bounds.y, supportImage.bounds.width, supportImage.bounds.height);
                 }
 
-                if(r.data.supportImageExt._private.supportImages.some(img => img.id === supportImage.id)){
+                if(r.data.supportImageExt._private.supportImages.length !== 0){
                   requestAnimationFrame(animateFrames);
                 } else {
                   r.redraw();

--- a/cytoscape-supportimages.js
+++ b/cytoscape-supportimages.js
@@ -735,7 +735,7 @@
                   context.drawImage(img, supportImage.bounds.x, supportImage.bounds.y, supportImage.bounds.width, supportImage.bounds.height);
                 }
 
-                if(r.data.supportImageExt._private.supportImages.length !== 0){
+                if(r.data.supportImageExt._private.supportImages.some(img => img.id === supportImage.id)){
                   requestAnimationFrame(animateFrames);
                 } else {
                   r.redraw();

--- a/cytoscape-supportimages.js
+++ b/cytoscape-supportimages.js
@@ -734,7 +734,12 @@
                 } else {
                   context.drawImage(img, supportImage.bounds.x, supportImage.bounds.y, supportImage.bounds.width, supportImage.bounds.height);
                 }
-                requestAnimationFrame(animateFrames);
+
+                if(r.data.supportImageExt._private.supportImages.some(img => img.id === supportImage.id)){
+                  requestAnimationFrame(animateFrames);
+                } else {
+                  r.redraw();
+                }
               }
 
               animateFrames();

--- a/cytoscape-supportimages.js
+++ b/cytoscape-supportimages.js
@@ -735,7 +735,7 @@
                   context.drawImage(img, supportImage.bounds.x, supportImage.bounds.y, supportImage.bounds.width, supportImage.bounds.height);
                 }
 
-                if(r.data.supportImageExt._private.supportImages.some(img => img.id === supportImage.id)){
+                if(r.data.supportImageExt._private.supportImages.some(img => img.id === supportImage.id && img.visible === true)){
                   requestAnimationFrame(animateFrames);
                 } else {
                   r.redraw();


### PR DESCRIPTION
Hello!

I have found an issue with the implementation I added for video support to the extension.  If a video is removed from the extension the animateFrames() function that animates the video will continue to run regardless of the video being removed.  I added a quick if statement within the function that checks if the video is still present.  This has fixed the issue for my purposes but could get very expensive performance wise if there are a lot of videos.  I do not have time to try and optimize this further right now but if you have any suggestions I can look into it when I do!  Let me know what you think. 